### PR TITLE
refactor: relocated methods after data readers

### DIFF
--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe StatTracker do
     
     end
 
-    describe 'highest_total_score' do
-        it 'returns highest sum of the winning and losing teams scores' do
-            expect(@stat_tracker.highest_total_score).to eq(5)
-        end
-    end
-
     describe "game_reader" do
         it "returns a hash with keys set to game_id, value is the relevant game object" do
             games_data = StatTracker.game_reader(@locations[:games])
@@ -104,6 +98,12 @@ RSpec.describe StatTracker do
             row_count = CSV.read(@locations[:game_teams], headers: true).size
 
             expect(seasons_data.length).to eq(row_count)
+        end
+    end
+
+    describe 'highest_total_score' do
+        it 'returns highest sum of the winning and losing teams scores' do
+            expect(@stat_tracker.highest_total_score).to eq(5)
         end
     end
 


### PR DESCRIPTION
Rearranged highest_total_score method to be below all of our data reader tests in stat_tracker_spec. All subsequent methods will be below all initialize methods/ data reader. This should lead to better layout and organization.