### PR TITLE
Feat/#most accurate team

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -249,11 +249,8 @@ class StatTracker
     def most_accurate_team(specific_season)
         teams_data = teams_shots_and_goals(all_games_ids_in_specified_season(specific_season))
         
-        most_accurate = teams_data.max_by do |team_id, team_data| 
-            next if team_data[:goals] == 0
-            next if team_data[:shots] == 0
-            team_data[:goals].to_f / team_data[:shots]
-        end
+        most_accurate = teams_data.reject { |_, team_data| team_data[:shots] == 0 || team_data[:goals] == 0 }
+        .max_by { |_, team_data| team_data[:goals].to_f / team_data[:shots] }
   
         id_to_name(most_accurate[0])
     end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -223,10 +223,40 @@ class StatTracker
         #
 
     end
-    
-    # def most_accurate_team
 
-    # end
+    def all_games_ids_in_specified_season(specific_season)
+        
+        games_in_seasons = @game_stats_data.find_all { |game_id, game_object| game_object.season == specific_season.to_i}
+        game_ids_in_season = games_in_seasons.map { |game_id, game_object| game_id }
+        
+    end
+
+    def teams_shots_and_goals(game_ids)
+        teams_data = Hash.new { |hash, key| hash[key] = { goals: 0, shots: 0 } }
+
+        @seasons_stats_data.each do |counter, season_object|
+            
+            next unless game_ids.include?(season_object.game_id)
+           
+            teams_data[season_object.team_id][:goals] += season_object.goals
+            teams_data[season_object.team_id][:shots] += season_object.shots
+        end
+
+        teams_data
+    end
+   
+
+    def most_accurate_team(specific_season)
+        teams_data = teams_shots_and_goals(all_games_ids_in_specified_season(specific_season))
+        
+        most_accurate = teams_data.max_by do |team_id, team_data| 
+            next if team_data[:goals] == 0
+            next if team_data[:shots] == 0
+            team_data[:goals].to_f / team_data[:shots]
+        end
+  
+        id_to_name(most_accurate[0])
+    end
     
     def least_accurate_team(specific_season)
         specific_season_integer = specific_season.to_i

--- a/runner.rb
+++ b/runner.rb
@@ -12,8 +12,5 @@ season_data = {
 }
 
 stat_tracker = StatTracker.from_csv(season_data)
-puts stat_tracker.highest_total_score
-puts stat_tracker.class
 
-puts Object.superclass
-puts BasicObject.superclass
+stat_tracker.most_accurate_team(20122013)

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -351,10 +351,19 @@ RSpec.describe StatTracker do
         end
     end
 
-    describe ""
+    describe "teams_shots_and_goals" do
+        it "returns a hash of all teams with shots and goals" do
+            data = [2012030221, 2012030222]
+            require 'pry', binding.pry
+            expect(@stat_tracker.teams_shots_and_goals(data)).to eq {3=>{:goals=>4, :shots=>17}, 6=>{:goals=>6, :shots=>20}}
+        end
+    end
     
     describe 'most_accurate_team' do
+        it "returns the most accurate team" do
 
+
+        end
     end
     
     describe 'least_accurate_team' do

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -354,15 +354,23 @@ RSpec.describe StatTracker do
     describe "teams_shots_and_goals" do
         it "returns a hash of all teams with shots and goals" do
             data = [2012030221, 2012030222]
-            require 'pry', binding.pry
-            expect(@stat_tracker.teams_shots_and_goals(data)).to eq {3=>{:goals=>4, :shots=>17}, 6=>{:goals=>6, :shots=>20}}
+            
+            expect(@stat_tracker.teams_shots_and_goals(data)).to eq ({3=>{:goals=>4, :shots=>17}, 6=>{:goals=>6, :shots=>20}})
         end
     end
     
     describe 'most_accurate_team' do
         it "returns the most accurate team" do
+            allow(@stat_tracker).to receive(:all_games_ids_in_specified_season).and_return([2012030221, 2012030222])
 
+            expect(@stat_tracker.most_accurate_team(20122014)).to eq("FC Dallas")
+        end
 
+        it "handles edge cases where a team has 0 goals or 0 shots (division by zero)" do
+            allow(@stat_tracker).to receive(:all_games_ids_in_specified_season).and_return([2012030221, 2012030222])
+            allow(@stat_tracker).to receive(:teams_shots_and_goals).and_return({3=>{:goals=>4, :shots=>17}, 6=>{:goals=>0, :shots=>20}})
+
+            expect(@stat_tracker.most_accurate_team(20122014)).to eq("Houston Dynamo")
         end
     end
     

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -3,17 +3,31 @@ require 'spec_helper'
 
 RSpec.describe StatTracker do
     before(:each) do
-        game_path = './data/games_dummy.csv'
-        team_path = './data/teams_dummy.csv'
-        game_teams_path = './data/game_teams_dummy.csv'
+        # # Test Data
+        game_path_dummy = './data/games_dummy.csv'
+        team_path_dummy = './data/teams_dummy.csv'
+        game_teams_path_dummy = './data/game_teams_dummy.csv'
 
         @locations = {
-            games: game_path,
-            teams: team_path,
-            game_teams: game_teams_path
-            }
+            games: game_path_dummy,
+            teams: team_path_dummy,
+            game_teams: game_teams_path_dummy
+        }
 
         @stat_tracker = StatTracker.from_csv(@locations)
+
+        # #Actual Data
+        # game_path = './data/games.csv'
+        # team_path = './data/teams.csv'
+        # game_teams_path = './data/game_teams.csv'
+
+        # @locations_actual_data = {
+        #     games: game_path,
+        #     teams: team_path,
+        #     game_teams: game_teams_path
+        # }
+        
+        # @stat_tracker_large_data = StatTracker.from_csv(@locations_actual_data)
     end
 
     describe "initialize" do
@@ -323,10 +337,25 @@ RSpec.describe StatTracker do
             expect(@stat_tracker.worst_coach).to eq('ur mom')
         end
     end
-    
-    # describe 'most_accurate_team' do
 
-    # end
+    describe 'all_games_ids_in_specified_season' do
+        it 'returns all game_ids in the specified season' do
+            expect(@stat_tracker.all_games_ids_in_specified_season(20122013)).to eq [2012030221, 2012030222, 2012030223, 2012030224, 2012030225, 2012030311, 2012030312, 2012030313, 2012030314, 2012030231, 2012030232, 2012030233, 2012030234, 2012030235]
+
+            hash_of_games = @stat_tracker.instance_variable_get(:@game_stats_data)
+
+            hash_of_games[2012030221].instance_variable_set(:@season, 20122014) 
+            hash_of_games[2012030222].instance_variable_set(:@season, 20122014) 
+
+            expect(@stat_tracker.all_games_ids_in_specified_season(20122014)).to eq [2012030221, 2012030222]
+        end
+    end
+
+    describe ""
+    
+    describe 'most_accurate_team' do
+
+    end
     
     describe 'least_accurate_team' do
         it 'returns name of the Team with the worst ratio of shots to goals for the season.' do


### PR DESCRIPTION
Added 3 methods:

- `most_accurate_teams`
   - This method utilizes the helper methods below, and filters for the most accurate team by goals and shots.
   - It has built in edge case testing as shots and goals could either be equal to 0, and it has built in ways to work around these errors
- Helper Methods:
  - `all_games_ids_in_specified_season(specific_season)`
     - This methods checks a given season and returns a list of all games played in the season
  -  ` teams_shots_and_goals(game_ids)`
     - This methods takes a list of games played in a season, and returns a hash with the team_id as a key, and the value is another hash that contains shots and goals data

I also created their respective tests. 

